### PR TITLE
Add Fluent function to Tera, link to data context

### DIFF
--- a/.github/workflows/quick-check.yml
+++ b/.github/workflows/quick-check.yml
@@ -49,9 +49,15 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
+          args: --all-features -- -D warnings
 
   quick_check-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        feature-flags:
+          - ''
+          - '--all-features'
     runs-on: ubuntu-latest
     steps:
       - name: Install Rust stable toolchain
@@ -66,9 +72,9 @@ jobs:
       - name: Cargo test
         uses: actions-rs/cargo@v1
         with:
-          command: test
+          command: test ${{ matrix.feature-flags }}
 
       - name: Cargo check
         uses: actions-rs/cargo@v1
         with:
-          command: check
+          command: check ${{ matrix.feature-flags }}

--- a/.github/workflows/quick-check.yml
+++ b/.github/workflows/quick-check.yml
@@ -72,9 +72,11 @@ jobs:
       - name: Cargo test
         uses: actions-rs/cargo@v1
         with:
-          command: test ${{ matrix.feature-flags }}
+          command: test
+          args: ${{ matrix.feature-flags }}
 
       - name: Cargo check
         uses: actions-rs/cargo@v1
         with:
-          command: check ${{ matrix.feature-flags }}
+          command: check
+          args: ${{ matrix.feature-flags }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
+
+[[package]]
 name = "assert_cmd"
 version = "2.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,6 +266,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,6 +329,83 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "fluent"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61f69378194459db76abd2ce3952b790db103ceb003008d3d50d97c41ff847a7"
+dependencies = [
+ "fluent-bundle",
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-bundle"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e242c601dec9711505f6d5bbff5bedd4b61b2469f2e8bb8e57ee7c9747a87ffd"
+dependencies = [
+ "fluent-langneg",
+ "fluent-syntax",
+ "intl-memoizer",
+ "intl_pluralrules",
+ "rustc-hash",
+ "self_cell",
+ "smallvec",
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-langneg"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4ad0989667548f06ccd0e306ed56b61bd4d35458d54df5ec7587c0e8ed5e94"
+dependencies = [
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-syntax"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0abed97648395c902868fee9026de96483933faa54ea3b40d652f7dfe61ca78"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
+name = "fluent-templates"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c3ef2c2152757885365abce32ddf682746062f1b6b3c0824a29fbed6ee4d080"
+dependencies = [
+ "arc-swap",
+ "fluent",
+ "fluent-bundle",
+ "fluent-langneg",
+ "fluent-syntax",
+ "flume",
+ "heck",
+ "ignore",
+ "intl-memoizer",
+ "lazy_static",
+ "log",
+ "once_cell",
+ "serde_json",
+ "snafu",
+ "tera",
+ "unic-langid",
+]
+
+[[package]]
+name = "flume"
+version = "0.10.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
+dependencies = [
+ "spin",
 ]
 
 [[package]]
@@ -450,6 +544,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "intl-memoizer"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c310433e4a310918d6ed9243542a6b83ec1183df95dff8f23f87bb88a264a66f"
+dependencies = [
+ "type-map",
+ "unic-langid",
+]
+
+[[package]]
+name = "intl_pluralrules"
+version = "7.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078ea7b7c29a2b4df841a7f6ac8775ff6074020c6776d48491ce2268e068f972"
+dependencies = [
+ "unic-langid",
+]
+
+[[package]]
 name = "io-lifetimes"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -521,6 +634,16 @@ name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
+name = "lock_api"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -733,6 +856,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -804,6 +933,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustix"
 version = "0.36.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -833,10 +968,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
 name = "scratch"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
+
+[[package]]
+name = "self_cell"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ef965a420fe14fdac7dd018862966a4c14094f900e1650bbc71ddd7d580c8af"
 
 [[package]]
 name = "serde"
@@ -895,6 +1042,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "snafu"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0656e7e3ffb70f6c39b3c2a86332bb74aa3c679da781642590f3c1118c5045"
+dependencies = [
+ "doc-comment",
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "475b3bbe5245c26f2d8a6f62d67c1f30eb9fffeccee721c45d162c3ebbdf81b2"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dccf47db1b41fa1573ed27ccf5e08e3ca771cb994f776668c5ebda893b248fc"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -940,6 +1124,7 @@ dependencies = [
  "assert_cmd",
  "clap",
  "env_logger",
+ "fluent-templates",
  "log",
  "predicates",
  "serde",
@@ -994,12 +1179,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ac3f5b6856e931e15e07b478e98c8045239829a65f9156d4fa7e7788197a5ef"
+dependencies = [
+ "displaydoc",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "type-map"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d3364c5e96cb2ad1603037ab253ddd34d7fb72a58bdddf4b7350760fc69a46"
+dependencies = [
+ "rustc-hash",
 ]
 
 [[package]]
@@ -1043,6 +1246,49 @@ name = "unic-common"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc"
+
+[[package]]
+name = "unic-langid"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "398f9ad7239db44fd0f80fe068d12ff22d78354080332a5077dc6f52f14dcf2f"
+dependencies = [
+ "unic-langid-impl",
+ "unic-langid-macros",
+]
+
+[[package]]
+name = "unic-langid-impl"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35bfd2f2b8796545b55d7d3fd3e89a0613f68a0d1c8bc28cb7ff96b411a35ff"
+dependencies = [
+ "tinystr",
+]
+
+[[package]]
+name = "unic-langid-macros"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "055e618bf694161ffff0466d95cef3e1a5edc59f6ba1888e97801f2b4ebdc4fe"
+dependencies = [
+ "proc-macro-hack",
+ "tinystr",
+ "unic-langid-impl",
+ "unic-langid-macros-impl",
+]
+
+[[package]]
+name = "unic-langid-macros-impl"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f5cdec05b907f4e2f6843f4354f4ce6a5bebe1a56df320a49134944477ce4d8"
+dependencies = [
+ "proc-macro-hack",
+ "quote",
+ "syn",
+ "unic-langid-impl",
+]
 
 [[package]]
 name = "unic-segment"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,14 @@ name = "teracli"
 readme = "README.md"
 version = "0.2.3"
 
+[features]
+default = []
+fluent = ["fluent-templates"]
+
 [dependencies]
 clap = { version = "4", features = ["derive", "env", "unicode", "cargo"] }
 env_logger = "0.10"
+fluent-templates = { version = "0.8", optional = true, default-features = false, features = ["tera"]}
 log = "0.4"
 serde = "1.0"
 serde_json = { version = "1.0", optional = false }

--- a/data/basic/fluent.tera
+++ b/data/basic/fluent.tera
@@ -1,0 +1,1 @@
+{{ fluent(key="hello", name=en) }} {{ fluent(key="hello", lang="tr-TR", name=tr) }}

--- a/data/basic/fluent.yaml
+++ b/data/basic/fluent.yaml
@@ -1,0 +1,2 @@
+en: World
+tr: Dünya

--- a/data/locales/en-US/test.ftl
+++ b/data/locales/en-US/test.ftl
@@ -1,0 +1,1 @@
+hello = Hello { $name }!

--- a/data/locales/tr-TR/test.ftl
+++ b/data/locales/tr-TR/test.ftl
@@ -1,0 +1,1 @@
+hello = Merhaba { $name }!

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ fn main() -> Result<(), String> {
 	let context: &Context = wrapped_context.context();
 	trace!("context:\n{:#?}", context);
 
-	let rendered;
+	let mut tera: Tera;
 
 	if include {
 		let mut dir = path.to_str().unwrap();
@@ -47,22 +47,22 @@ fn main() -> Result<(), String> {
 
 		let glob = dir.to_owned() + "/**/*";
 
-		let mut tera = match Tera::new(&glob) {
+		tera = match Tera::new(&glob) {
 			Ok(t) => t,
 			Err(e) => {
 				println!("Parsing error(s): {e}");
 				::std::process::exit(1);
 			}
 		};
-
-		if !autoescape {
-			tera.autoescape_on(vec![]);
-		}
-
-		rendered = tera.render_str(&template, context).unwrap();
 	} else {
-		rendered = Tera::one_off(&template, context, autoescape).unwrap();
+		tera = Tera::default();
 	}
+
+	if !autoescape {
+		tera.autoescape_on(vec![])
+	};
+
+	let rendered = tera.render_str(&template, context).unwrap();
 
 	println!("{rendered}");
 

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -19,6 +19,16 @@ pub struct Opts {
 	#[clap(long, visible_alias = "inherit-path")]
 	pub include_path: Option<PathBuf>,
 
+	/// Option to set default locale used for Fluent localization functions.
+	#[cfg(feature = "fluent")]
+	#[clap(short, long)]
+	pub locale: Option<String>,
+
+	/// Option to define a path to Fluent resources used for localization.
+	#[cfg(feature = "fluent")]
+	#[clap(long, visible_alias = "locales-path")]
+	pub locales_path: Option<PathBuf>,
+
 	/// Location of the context data. This file can be of the following type:
 	/// json | toml | yaml. If you prefer to pass the data as stdin, use `--stdin`
 	#[clap(index = 1, required_unless_present_any = &["stdin", "env_only"], conflicts_with = "env_only")]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -47,6 +47,22 @@ mod cli_tests {
 			let assert = cmd.arg("-t").arg("data/basic/basic.tera").arg("data/basic/basic.toml").assert();
 			assert.success().stdout(predicate::str::contains("Bob likes orange"));
 		}
+
+		#[cfg(feature = "fluent")]
+		#[test]
+		fn it_proccess_fluent_functions() {
+			let mut cmd = Command::cargo_bin(env!("CARGO_BIN_EXE_tera")).unwrap();
+			let assert = cmd
+				.arg("-l")
+				.arg("en-US")
+				.arg("--locales-path")
+				.arg("data/locales/")
+				.arg("-t")
+				.arg("data/basic/fluent.tera")
+				.arg("data/basic/fluent.yaml")
+				.assert();
+			assert.success().stdout(predicate::str::contains("Hello World! Merhaba Dünya!"));
+		}
 	}
 
 	#[cfg(test)]


### PR DESCRIPTION
Closes #20.

I'm not super happy with the ergonomics here. Part of the problem turned out to be the `fluent-template` crates resource loader wasn't quite as robust as hoped. Second there doesn't seem to be an easy way to make it cooperate with locales that don't have resource directories. We can fallback to a single FTL resource, but a directory still has to exist for any locales one attempts to use. Hence I didn't even include a way to pass a single file yet. I have an upstream issue open about that and am hoping to come up with a way to make this usable with just passing a single FTL file like one might pass a specific context file.

I don't think this will break any current usage at all.
