### PR TITLE
Remove `.unwrap`s and `.expect`s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,6 +125,21 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "bitflags"
@@ -236,6 +266,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
+name = "color-eyre"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f1885697ee8a177096d42f158922251a41973117f6d8a234cee94b9509157b7"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6eee477a4a8a72f4addd4de416eb56d54bc307b284d6601bafdee1f4ea462d1"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,6 +400,16 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "eyre"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
+dependencies = [
+ "indenter",
+ "once_cell",
 ]
 
 [[package]]
@@ -459,6 +526,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
+
+[[package]]
 name = "globset"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -554,6 +627,12 @@ dependencies = [
  "walkdir",
  "winapi-util",
 ]
+
+[[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
@@ -678,6 +757,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,10 +781,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.30.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+
+[[package]]
+name = "owo-colors"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2386b4ebe91c2f7f51082d4cefa145d030e33a1842a96b12e4885cc3c01f7a55"
 
 [[package]]
 name = "parse-zoneinfo"
@@ -795,6 +898,12 @@ dependencies = [
  "siphasher",
  "uncased",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "ppv-lite86"
@@ -911,6 +1020,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1005,6 +1120,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1116,6 +1240,7 @@ version = "0.2.4"
 dependencies = [
  "assert_cmd",
  "clap",
+ "color-eyre",
  "env_logger",
  "fluent-templates",
  "log",
@@ -1212,6 +1337,60 @@ dependencies = [
  "serde_spanned",
  "toml_datetime",
  "winnow",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4d7c0b83d4a500748fa5879461652b361edf5c9d51ede2a2ac03875ca185e24"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
 ]
 
 [[package]]
@@ -1369,6 +1548,12 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ fluent = ["fluent-templates"]
 
 [dependencies]
 clap = { version = "4", features = ["derive", "env", "unicode", "cargo"] }
+color-eyre = "0.5"
 env_logger = "0.10"
 fluent-templates = { version = "0.8", optional = true, default-features = false, features = ["tera"]}
 log = "0.4"

--- a/data/throw/throw.tera
+++ b/data/throw/throw.tera
@@ -1,0 +1,1 @@
+{{ throw(message="some failure") }}

--- a/src/wrapped_context.rs
+++ b/src/wrapped_context.rs
@@ -1,4 +1,5 @@
 use crate::opts::Opts;
+use color_eyre::eyre::{bail, Context as EyreContext, ContextCompat, Result};
 use log::{debug, info, trace, warn};
 use serde_json::{self, json};
 use std::{
@@ -35,35 +36,41 @@ impl WrappedContext {
 		&self.context
 	}
 
-	pub fn append_json(&mut self, str: &str) {
+	pub fn append_json(&mut self, str: &str) -> Result<()> {
 		debug!("Appending json");
-		let json = str.parse::<serde_json::Value>().expect("JSON parsing");
-		let object = json.as_object().expect("JSON as object");
+		let json = str.parse::<serde_json::Value>().context("failed to parse JSON")?;
+		let object = json.as_object().context("JSON value must be an object")?;
 
 		for (k, v) in object.iter() {
 			self.handle_collision("json", k, v);
 		}
+
+		Ok(())
 	}
 
-	pub fn append_toml(&mut self, str: &str) {
+	pub fn append_toml(&mut self, str: &str) -> Result<()> {
 		debug!("Appending toml");
-		let value = str.parse::<toml::Value>().expect("TOML Parsing");
-		let table = value.as_table().expect("TOML as table");
+		let value = str.parse::<toml::Value>().context("failed to parse TOML")?;
+		let table = value.as_table().context("TOML value must be a table")?;
 
 		for (k, v) in table.iter() {
 			self.handle_collision("toml", k, v);
 		}
+
+		Ok(())
 	}
 
-	pub fn append_yaml(&mut self, str: &str) {
+	pub fn append_yaml(&mut self, str: &str) -> Result<()> {
 		debug!("Appending yaml");
-		let value: serde_yaml::Value = serde_yaml::from_str(str).expect("YAML parsing");
-		let mapping = value.as_mapping().expect("YAML as mapping");
+		let value: serde_yaml::Value = serde_yaml::from_str(str).context("failed to parse YAML")?;
+		let mapping = value.as_mapping().context("YAML value must be a mapping")?;
 
 		for (k, v) in mapping.iter() {
-			let k = k.as_str().unwrap();
+			let k = k.as_str().context("YAML mapping's key must be a string")?;
 			self.handle_collision("yaml", k, v);
 		}
+
+		Ok(())
 	}
 
 	fn handle_collision<K, V>(&mut self, from: &str, k: K, v: V)
@@ -134,7 +141,7 @@ impl WrappedContext {
 		None
 	}
 
-	pub fn create_context(&mut self) {
+	pub fn create_context(&mut self) -> Result<()> {
 		if (self.opts.env || self.opts.env_only) && self.opts.env_first {
 			info!("Appending env to context first, env-key: {:?}", self.opts.env_key);
 			self.append_env();
@@ -144,35 +151,34 @@ impl WrappedContext {
 			let stdin = io::stdin();
 			let mut stdin = stdin.lock();
 			let mut buf: Vec<u8> = Vec::with_capacity(BUFFER_SIZE);
-			let res = stdin.read_to_end(&mut buf).map_err(|e| e.to_string());
-			res.expect("Failed reading stdin");
-			let input = String::from_utf8(buf.to_vec()).unwrap();
+			stdin.read_to_end(&mut buf).context("failed to read stdin")?;
+			let input = String::from_utf8(buf.to_vec()).context("invalid UTF8 string")?;
 
 			match Self::get_type(&input) {
 				Some(SupportedType::Json) if !input.is_empty() => self.append_json(&input),
 				Some(SupportedType::Toml) if !input.is_empty() => self.append_toml(&input),
 				Some(SupportedType::Yaml) if !input.is_empty() => self.append_yaml(&input),
-				_ => {}
+				_ => Ok(()),
 			}
-		} else if self.opts.context.is_some() {
-			// here we know that we have a Path since --stdin is not passed
-			let context_file = self.opts.context.as_ref().unwrap();
-			let input = fs::read_to_string(context_file).unwrap();
+			.context("failed to append stdin to context")?;
+		} else if let Some(context_file) = &self.opts.context {
+			let input = fs::read_to_string(context_file).context("failed to read context file")?;
 
 			match context_file.extension() {
 				Some(ext) if ext == "json" => self.append_json(&input),
 				Some(ext) if ext == "toml" => self.append_toml(&input),
 				Some(ext) if ext == "yaml" || ext == "yml" => self.append_yaml(&input),
-				ext => {
-					panic!("Extension not supported: {ext:?}")
-				}
-			};
-		};
+				ext => bail!("extension not supported: {ext:?}"),
+			}
+			.context("failed to append file to context")?;
+		}
 
 		if (self.opts.env || self.opts.env_only) && !self.opts.env_first {
 			info!("Appending env to context, env-key: {:?}", self.opts.env_key);
 			self.append_env();
 		}
+
+		Ok(())
 	}
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -250,5 +250,12 @@ mod cli_tests {
 			let assert = cmd.arg("-t").arg("data/cargo-toml/cargo-toml.tera").arg("Cargo.toml").assert();
 			assert.success().code(0);
 		}
+
+		#[test]
+		fn it_handles_error() {
+			let mut cmd = Command::cargo_bin("tera").unwrap();
+			let assert = cmd.arg("-t").arg("data/throw/throw.tera").arg("data/throw/throw.toml").assert();
+			assert.failure().code(1);
+		}
 	}
 }


### PR DESCRIPTION
Some idiomatic construct.

I was actually interested in displaying more human-friendly error messages (see `throw`) but saw you always use `panic`. I'm used to return `anyhow::Result`. Then, just replace all `.unwrap()` with `?`. It not as human-friendly as a CLI should be, but at least it displays the error's source chain.