### PR TITLE
Add Nix Flake

### DIFF
--- a/.github/workflows/quick-check.yml
+++ b/.github/workflows/quick-check.yml
@@ -80,3 +80,23 @@ jobs:
         with:
           command: check
           args: ${{ matrix.feature-flags }}
+
+  quick_check-flake:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v4
+
+      - name: Cache Nix dependencies
+        uses: DeterminateSystems/magic-nix-cache-action@v2
+
+      - uses: actions/checkout@v2
+
+      - name: Check flake
+        run: nix flake check
+
+      - name: Build flake
+        run: nix build
+
+      - name: Test run flake
+        run: nix run . -- --version

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, naersk
+, stdenv
+, hostPlatform
+, targetPlatform
+, cargo
+, rustc
+}:
+let
+  cargoToml = (builtins.fromTOML (builtins.readFile ./Cargo.toml));
+in
+naersk.lib."${targetPlatform.system}".buildPackage rec {
+  src = ./.;
+  buildInputs = [
+    cargo
+    rustc
+  ];
+  cargoBuildOptions = final: final ++ [ "--all-features" ];
+  CARGO_BUILD_INCREMENTAL = "false";
+  copyLibs = true;
+  name = cargoToml.package.name;
+  version = cargoToml.package.version;
+  meta = with lib; {
+    description = cargoToml.package.description;
+    homepage = cargoToml.package.homepage;
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ ];
+    mainProgram = "tera";
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "naersk": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1688229166,
+        "narHash": "sha256-9lGDg8K1ASjTThzYjctdgd35WqocIIeakQXs5tAbQsM=",
+        "owner": "nmattia",
+        "repo": "naersk",
+        "rev": "714e701eb4ca2491d34d794b98be4b994a796ae7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nmattia",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1688221086,
+        "narHash": "sha256-cdW6qUL71cNWhHCpMPOJjlw0wzSRP0pVlRn2vqX/VVg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "cd99c2b3c9f160cd004318e0697f90bbd5960825",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,47 @@
+{
+  description = "A command line utility written in Rust to render templates from json|toml|yaml && ENV, using the tera templating engine";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    naersk.url = "github:nmattia/naersk";
+    naersk.inputs.nixpkgs.follows = "nixpkgs";
+  };
+  outputs = { self, nixpkgs, naersk }:
+    let
+      cargoToml = (builtins.fromTOML (builtins.readFile ./Cargo.toml));
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];
+      forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: f system);
+    in
+    {
+      overlay = final: prev: {
+        "${cargoToml.package.name}" = final.callPackage ./. { inherit naersk; };
+      };
+      packages = forAllSystems (system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [
+              self.overlay
+            ];
+          };
+        in
+        {
+          "${cargoToml.package.name}" = pkgs."${cargoToml.package.name}";
+        });
+      defaultPackage = forAllSystems (system: (import nixpkgs {
+        inherit system;
+        overlays = [ self.overlay ];
+      })."${cargoToml.package.name}");
+      devShell = forAllSystems (system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ self.overlay ];
+          };
+        in
+        pkgs.mkShell {
+          inputsFrom = with pkgs; [
+            pkgs."${cargoToml.package.name}"
+          ];
+        });
+    };
+}


### PR DESCRIPTION
This will enable the GitHub repository to be executed directly as a Nix command, quite useful for CI runners and projects using Nix as a build environment.

    nix run chevdor/tera-cli