### PR TITLE
fix(github-actions): avoid using the deprecated version of `actions/upload-artifact`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           cargo deb -p teracli -o "tera-cli_linux_amd64.deb"
 
       - name: Upload Linux artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: linux
           path: "tera-cli_linux_amd64.deb"
@@ -81,7 +81,7 @@ jobs:
           echo "SHA256=$SHA256" >> $GITHUB_ENV
 
       - name: Upload MacOS artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: macos
           path: |


### PR DESCRIPTION
`actions/upload-artifact` v2 is deprecated, so GitHub Actions will be failed as follows.

```  console
This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
```

## GitHub Actions Results

- [`actions/upload-artifact` v2 (deprecated)](https://github.com/hituzi-no-sippo/tera-cli/actions/runs/10930791252)
- [`actions/upload-artifact` v4](https://github.com/hituzi-no-sippo/tera-cli/actions/runs/10930791509)

## References

- [Deprecation notice: v1 and v2 of the artifact actions](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/)