### PR TITLE
ci(github-releases): add GitHub actions to add binaries to GitHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,3 +197,35 @@ jobs:
           asset_path: "macos/tera-macos-${{ env.RELEASE_VERSION }}.tar.gz"
           asset_name: "tera-macos-${{ env.RELEASE_VERSION }}.tar.gz"
           asset_content_type: application/gzip
+
+  upload-binaries:
+    needs: ["create_draft"]
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+          - os: macos-latest
+            target: x86_64-apple-darwin
+          - os: macos-latest
+            target: aarch64-apple-darwin
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          bin: tera
+          target: ${{ matrix.target }}
+          archive: tera-cli-$target
+          checksum: sha512
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,8 +150,14 @@ jobs:
 
       - name: Render release notes
         run: |
+          export X86_64_GNU_TGZ_URL="https://github.com/chevdor/tera-cli/releases/download/${{ env.RELEASE_VERSION }}/tera-cli-x86_64-unknown-linux-gnu.tar.gz"
+          export X86_64_MUSL_TGZ_URL="https://github.com/chevdor/tera-cli/releases/download/${{ env.RELEASE_VERSION }}/tera-cli-x86_64-unknown-linux-musl.tar.gz"
+          export AARCH64_GNU_TGZ_URL="https://github.com/chevdor/tera-cli/releases/download/${{ env.RELEASE_VERSION }}/tera-cli-aarch64-unknown-linux-gnu.tar.gz"
+          export AARCH64_MUSL_TGZ_URL="https://github.com/chevdor/tera-cli/releases/download/${{ env.RELEASE_VERSION }}/tera-cli-aarch64-unknown-linux-musl.tar.gz"
           export DEBIAN_URL="https://github.com/chevdor/tera-cli/releases/download/${{ env.RELEASE_VERSION }}/tera-cli_linux_amd64.deb"
           export MACOS_TGZ_URL="https://github.com/chevdor/tera-cli/releases/download/${{ env.RELEASE_VERSION }}/tera-macos-${{ env.RELEASE_VERSION }}.tar.gz"
+          export WINDOWS_ZIP_URL="https://github.com/chevdor/tera-cli/releases/download/${{ env.RELEASE_VERSION }}/tera-cli-aarch64-unknown-linux-musl.tar.gz"
+
           export CHANGELOG=$(cat changelog.md)
           tera --env --env-only --template templates/release.md > RELEASE_NOTES.md
 

--- a/templates/release.md
+++ b/templates/release.md
@@ -6,9 +6,16 @@ You can find the changelogs below.
 
 Download the binary for your OS from below:
 - **Linux**
+    - [x86_64 gnu]({{ X86_64_GNU_TGZ_URL }})
+    - [x86_64 musl]({{ X86_64_MUSL_TGZ_URL }})
+    - [aarch64 gnu]({{ AARCH64_GNU_TGZ_URL }})
+    - [aarch64 musl]({{ AARCH64_MUSL_TGZ_URL }})
     - [Debian package]({{ DEBIAN_URL }})
 - **MacOS**
     - [Archive]({{ MACOS_TGZ_URL }})
+- **Windows**
+    - [Archive]({{ WINDOWS_ZIP_URL }})
+
 # Install
 
 ## From source
@@ -18,6 +25,17 @@ cargo install --git https://github.com/chevdor/tera-cli
 ```
 
 ## Linux
+
+### Binaries
+
+```
+wget {{ X86_64_GNU_TGZ_URL }}
+tar xf tera-cli-x86_64-unknown-linux-gnu.tar.gz
+./tera --help
+```
+
+### Debian
+
 ```
 wget {{ DEBIAN_URL }}
 dpkg -i tera-cli_linux_amd64.deb


### PR DESCRIPTION
First of all, Thanks for creating this awesome tool.

This PR adds a GitHub Action to add binaries to GitHub Releases.

The reason for creating this PR, I would like to download `tera-cli` via [aqua](https://aquaproj.github.io) without using cargo.