### PR TITLE
ci: add GitHub actions to add binaries to GitHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,11 +249,14 @@ jobs:
 
       - name: Upload x86_64
         uses: taiki-e/upload-rust-binary-action@v1
+        id: upload-x86_64
         with:
           bin: tera
           target: x86_64-apple-darwin
           archive: tera-cli-$target
-          checksum: sha512
+          # SHA256 is used for homebrew
+          # https://docs.brew.sh/Cask-Cookbook#stanza-sha256
+          checksum: sha256,sha512
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload aarch64
@@ -264,3 +267,37 @@ jobs:
           archive: tera-cli-$target
           checksum: sha512
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Add tera to PATH
+        run: |
+          mv "target/x86_64-apple-darwin/release/tera" /usr/local/bin
+
+      - name: Output values for Formula templates
+        id: output-values-for-templates
+        run: |
+          echo "raw_version=${GITHUB_REF_NAME:1}" >> $GITHUB_OUTPUT
+
+          x86_64_sha256="$(cut -d' ' -f1 ${{ steps.upload-x86_64.outputs.sha256 }})"
+          echo "x86_64_sha256=$x86_64_sha256" >> $GITHUB_OUTPUT
+
+      # We do that before hecking out master (in case we were not in master already)
+      - name: Prepare new Formula
+        env:
+          NAME: Tera
+          DESCRIPTION: "A command line utility written in Rust to render templates using the tera templating engine"
+          HOMEPAGE: ${{ github.server_url }}/${{ github.repository }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+          ARCHIVE: tera-cli-x86_64-apple-darwin.tar.gz
+          SHA256: ${{ steps.output-values-for-templates.outputs.x86_64_sha256 }}
+          VERSION: ${{ steps.output-values-for-templates.outputs.raw_version }}
+        run: |
+          tera --version
+          tera --template templates/formula.rb --env-only > $HOME/tera.rb
+          cat $HOME/tera.rb
+
+      - name: Update Homebrew Formula
+        run: |
+          cp -f $HOME/tera.rb Formula/tera.rb
+          git config --global user.name 'TeraBot'
+          git config --global user.email 'chevdor@users.noreply.github.com'
+          git commit Formula/tera.rb -m "build: new homebrew formula for ${GITHUB_REF_NAME}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,10 +150,22 @@ jobs:
 
       - name: Render release notes
         run: |
+          x86_64_prefix='tera-cli-x86_64-'
+
+          export X86_64_GNU_TGZ="${x86_64_prefix}unknown-linux-gnu.tar.gz"
+          export X86_64_MUSL_TGZ="${X86_64_GNU_TGZ//gnu/musl}"
+
+          export AARCH64_GNU_TGZ="${X86_64_GNU_TGZ//x86_64/aarch64}"
+          export AARCH64_MUSL_TGZ="${X86_64_MUSL_TGZ//x86_64/aarch64}"
+
           export DEBIAN_URL="https://github.com/chevdor/tera-cli/releases/download/${{ env.RELEASE_VERSION }}/tera-cli_linux_amd64.deb"
           export MACOS_TGZ_URL="https://github.com/chevdor/tera-cli/releases/download/${{ env.RELEASE_VERSION }}/tera-macos-${{ env.RELEASE_VERSION }}.tar.gz"
+
           export CHANGELOG=$(cat changelog.md)
           tera --env --env-only --template templates/release.md > RELEASE_NOTES.md
+        env:
+          ARCHIVE_URL_PREFIX: ${{ github.server_url }}/${{ github.repository }}/releases/download/${{ env.RELEASE_VERSION }}/
+          WINDOWS_ZIP: tera-cli-x86_64-pc-windows-msvc.zip
 
       - name: Create Release
         id: create-release
@@ -197,3 +209,32 @@ jobs:
           asset_path: "macos/tera-macos-${{ env.RELEASE_VERSION }}.tar.gz"
           asset_name: "tera-macos-${{ env.RELEASE_VERSION }}.tar.gz"
           asset_content_type: application/gzip
+
+  publish-linux-and-windowns-binaries:
+    needs: ["create_draft"]
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Upload Binarise
+        uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          bin: tera
+          target: ${{ matrix.target }}
+          archive: tera-cli-$target
+          checksum: sha512
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,83 +36,8 @@ jobs:
           name: linux
           path: "tera-cli_linux_amd64.deb"
 
-  macos:
-    env:
-      TARGET_DIR: target/release
-
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Get Release Version
-        run: |
-          echo GITHUB_REF=$GITHUB_REF
-          RELEASE_VERSION=${GITHUB_REF#refs/*/}
-          RAW_VERSION=${RELEASE_VERSION:1}
-          echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
-          echo "RAW_VERSION=$RAW_VERSION" >> $GITHUB_ENV
-          echo "SHORT_SHA=${GITHUB_SHA::8}" >> $GITHUB_ENV
-
-      - name: Install latest nightly
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          override: true
-          components: rustfmt, clippy
-
-      - name: Check tooling
-        shell: bash
-        run: |
-          tar --version
-          shasum --version
-
-      - name: Build MacOS binary
-        shell: bash
-        run: |
-          cargo build --release
-          cp "${{ env.TARGET_DIR }}/tera" /usr/local/bin
-
-      - name: Compress & sha256
-        run: |
-          tar -czf ${{ env.TARGET_DIR }}/tera-macos-${{ env.RELEASE_VERSION }}.tar.gz -C ${{ env.TARGET_DIR }} tera
-          SHA256=$(shasum -a 256 ${{ env.TARGET_DIR }}/tera-macos-${{ env.RELEASE_VERSION }}.tar.gz | awk '{ print $1}' | tee ${{ env.TARGET_DIR }}/tera-macos-${{ env.RELEASE_VERSION }}.tar.gz.sha256)
-          echo SHA256: $SHA256
-          echo "SHA256=$SHA256" >> $GITHUB_ENV
-
-      - name: Upload MacOS artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: macos
-          path: |
-            ${{ env.TARGET_DIR }}/tera
-            ${{ env.TARGET_DIR }}/tera-macos-${{ env.RELEASE_VERSION }}.tar.gz
-            ${{ env.TARGET_DIR }}/tera-macos-${{ env.RELEASE_VERSION }}.tar.gz.sha256
-
-      # We do that before checking out master (in case we were not in master already)
-      - name: Prepare new Formula
-        env:
-          NAME: Tera
-          DESCRIPTION: "A command line utility written in Rust to render templates using the tera templating engine"
-          SITE: https://github.com
-          REPO: chevdor/tera-cli
-          SHA256: ${{env.SHA256}}
-          VERSION: ${{env.RAW_VERSION}}
-        run: |
-          tera --version
-          tera --template templates/formula.rb --env-only > $HOME/tera.rb
-          cat $HOME/tera.rb
-
-      - name: Update Homebrew Formula
-        run: |
-          cp -f $HOME/tera.rb Formula/tera.rb
-          git config --global user.name 'TeraBot'
-          git config --global user.email 'chevdor@users.noreply.github.com'
-          git commit Formula/tera.rb -m "build: new homebrew formula for ${{ env.RELEASE_VERSION }}"
-          git push origin HEAD:master
-
   create_draft:
-    needs: ["linux", "macos"]
+    needs: ["linux"]
     name: Create Draft
     runs-on: ubuntu-latest
     outputs:
@@ -179,7 +104,7 @@ jobs:
           body_path: ./RELEASE_NOTES.md
           draft: true
 
-  publish-binaries:
+  publish-debian-package:
     runs-on: ubuntu-latest
     needs: ["create_draft"]
     steps:
@@ -200,16 +125,6 @@ jobs:
           asset_path: "linux/tera-cli_linux_amd64.deb"
           asset_name: "tera-cli_linux_amd64.deb"
           asset_content_type: application/vnd.debian.binary-package
-
-      - name: Upload MacOS archive
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_draft.outputs.asset_upload_url }}
-          asset_path: "macos/tera-macos-${{ env.RELEASE_VERSION }}.tar.gz"
-          asset_name: "tera-macos-${{ env.RELEASE_VERSION }}.tar.gz"
-          asset_content_type: application/gzip
 
   publish-linux-and-windowns-binaries:
     needs: ["create_draft"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,7 +159,8 @@ jobs:
           export AARCH64_MUSL_TGZ="${X86_64_MUSL_TGZ//x86_64/aarch64}"
 
           export DEBIAN_URL="https://github.com/chevdor/tera-cli/releases/download/${{ env.RELEASE_VERSION }}/tera-cli_linux_amd64.deb"
-          export MACOS_TGZ_URL="https://github.com/chevdor/tera-cli/releases/download/${{ env.RELEASE_VERSION }}/tera-macos-${{ env.RELEASE_VERSION }}.tar.gz"
+          export X86_64_MACOS_TGZ="${x86_64_prefix}apple-darwin.tar.gz"
+          export AARCH64_MACOS_TGZ="${X86_64_MACOS_TGZ//x86_64/aarch64}"
 
           export CHANGELOG=$(cat changelog.md)
           tera --env --env-only --template templates/release.md > RELEASE_NOTES.md
@@ -235,6 +236,31 @@ jobs:
         with:
           bin: tera
           target: ${{ matrix.target }}
+          archive: tera-cli-$target
+          checksum: sha512
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-macos-binaries:
+    needs: ["create_draft"]
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Upload x86_64
+        uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          bin: tera
+          target: x86_64-apple-darwin
+          archive: tera-cli-$target
+          checksum: sha512
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload aarch64
+        uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          bin: tera
+          target: aarch64-apple-darwin
           archive: tera-cli-$target
           checksum: sha512
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,11 +176,12 @@ jobs:
 
       - name: Upload aarch64
         uses: taiki-e/upload-rust-binary-action@v1
+        id: upload-aarch64
         with:
           bin: tera
           target: aarch64-apple-darwin
           archive: tera-cli-$target
-          checksum: sha512
+          checksum: sha256,sha512
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Add tera to PATH
@@ -194,6 +195,8 @@ jobs:
 
           x86_64_sha256="$(cut -d' ' -f1 ${{ steps.upload-x86_64.outputs.sha256 }})"
           echo "x86_64_sha256=$x86_64_sha256" >> $GITHUB_OUTPUT
+          aarch64_sha256="$(cut -d' ' -f1 ${{ steps.upload-aarch64.outputs.sha256 }})"
+          echo "aarch64_sha256=$aarch64_sha256" >> $GITHUB_OUTPUT
 
       # We do that before hecking out master (in case we were not in master already)
       - name: Prepare new Formula
@@ -202,8 +205,8 @@ jobs:
           DESCRIPTION: "A command line utility written in Rust to render templates using the tera templating engine"
           HOMEPAGE: ${{ github.server_url }}/${{ github.repository }}
           REPO_URL: ${{ github.server_url }}/${{ github.repository }}
-          ARCHIVE: tera-cli-x86_64-apple-darwin.tar.gz
-          SHA256: ${{ steps.output-values-for-templates.outputs.x86_64_sha256 }}
+          X86_64_SHA256: ${{ steps.output-values-for-templates.outputs.x86_64_sha256 }}
+          AARCH64_SHA256: ${{ steps.output-values-for-templates.outputs.aarch64_sha256 }}
           VERSION: ${{ steps.output-values-for-templates.outputs.raw_version }}
         run: |
           tera --version
@@ -216,3 +219,4 @@ jobs:
           git config --global user.name 'TeraBot'
           git config --global user.email 'chevdor@users.noreply.github.com'
           git commit Formula/tera.rb -m "build: new homebrew formula for ${GITHUB_REF_NAME}"
+          git push origin HEAD:master

--- a/templates/formula.rb
+++ b/templates/formula.rb
@@ -4,7 +4,7 @@
 class {{ NAME }} < Formula
   desc "{{ DESCRIPTION }}"
   homepage "{{ HOMEPAGE }}"
-  url "{{ SITE }}/{{ REPO }}/releases/download/v{{ VERSION }}/{{ ARCHIVE | default(value=BIN ~"-macos-v" ~ VERSION) }}.tar.gz"
+  url "{{ REPO_URL }}/releases/download/v{{ VERSION }}/{{ ARCHIVE }}"
   sha256 "{{ SHA256 }}"
   version "{{ VERSION }}"
 

--- a/templates/formula.rb
+++ b/templates/formula.rb
@@ -2,10 +2,14 @@
 {%- set HOMEPAGE = HOMEPAGE | default(value=SITE ~ "/" ~ REPO) -%}
 
 class {{ NAME }} < Formula
+  arch arm: "aarch64", intel: 'x86_64'
+
   desc "{{ DESCRIPTION }}"
   homepage "{{ HOMEPAGE }}"
-  url "{{ REPO_URL }}/releases/download/v{{ VERSION }}/{{ ARCHIVE }}"
-  sha256 "{{ SHA256 }}"
+  url "{{ REPO_URL }}/releases/download/v{{ VERSION }}/tera-cli-#{arch}-apple-darwin.tar.gz"
+  sha256 arm:   "{{ AARCH64_SHA256 }}",
+         intel: "{{ X86_64_SHA256 }}"
+
   version "{{ VERSION }}"
 
   def install

--- a/templates/release.md
+++ b/templates/release.md
@@ -6,9 +6,16 @@ You can find the changelogs below.
 
 Download the binary for your OS from below:
 - **Linux**
+    - [x86_64 gnu]({{ ARCHIVE_URL_PREFIX ~ X86_64_GNU_TGZ }})
+    - [x86_64 musl]({{ ARCHIVE_URL_PREFIX ~ X86_64_MUSL_TGZ }})
+    - [aarch64 gnu]({{ ARCHIVE_URL_PREFIX ~ AARCH64_GNU_TGZ }})
+    - [aarch64 musl]({{ ARCHIVE_URL_PREFIX ~ AARCH64_MUSL_TGZ }})
     - [Debian package]({{ DEBIAN_URL }})
 - **MacOS**
     - [Archive]({{ MACOS_TGZ_URL }})
+- **Windows**
+    - [Archive]({{ ARCHIVE_URL_PREFIX ~ WINDOWS_ZIP }})
+
 # Install
 
 ## From source
@@ -18,6 +25,17 @@ cargo install --git https://github.com/chevdor/tera-cli
 ```
 
 ## Linux
+
+### Binaries
+
+```
+wget {{ ARCHIVE_URL_PREFIX ~ X86_64_GNU_TGZ }}
+tar xf {{ X86_64_GNU_TGZ }}
+./tera --help
+```
+
+### Debian
+
 ```
 wget {{ DEBIAN_URL }}
 dpkg -i tera-cli_linux_amd64.deb

--- a/templates/release.md
+++ b/templates/release.md
@@ -12,7 +12,8 @@ Download the binary for your OS from below:
     - [aarch64 musl]({{ ARCHIVE_URL_PREFIX ~ AARCH64_MUSL_TGZ }})
     - [Debian package]({{ DEBIAN_URL }})
 - **MacOS**
-    - [Archive]({{ MACOS_TGZ_URL }})
+    - [x86_64]({{ ARCHIVE_URL_PREFIX ~ X86_64_MACOS_TGZ }})
+    - [aarch64]({{ ARCHIVE_URL_PREFIX ~ AARCH64_MACOS_TGZ }})
 - **Windows**
     - [Archive]({{ ARCHIVE_URL_PREFIX ~ WINDOWS_ZIP }})
 


### PR DESCRIPTION
First of all, Thanks for creating this awesome tool.

This PR adds a GitHub Action to add binaries to GitHub Releases.

The reason for creating this PR, I would like to download `tera-cli` via [aqua](https://aquaproj.github.io) without using cargo.

- Test release
  https://github.com/hituzi-no-sippo/tera-cli/releases/tag/v0.4.2
- Result of GitHub Actions
  https://github.com/hituzi-no-sippo/tera-cli/actions/runs/11021567820

## TODO

- [x] Assets
  - [x] Add archives generated by `taiki-e/upload-rust-binary-action`
  - [x] Remove MacOS archives created using shell.

- [x] Homebrew
  - [x] Change the archive URL to the archive generated by `taiki-e/upload-rust-binary-action`
  - [x]  Add arm support

- [x] Release Note
  - [x] Add the links to archives generated by `taiki-e/upload-rust-binary-action`
  - [x] Add the usage of Linux archives.
   
#31 were closed because I deleted the branch by mistake.