### PR TITLE
Enable date localization feature of tera

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,6 +195,7 @@ dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
+ "pure-rust-locales",
  "windows-targets",
 ]
 
@@ -939,6 +940,12 @@ checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pure-rust-locales"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1190fd18ae6ce9e137184f207593877e70f39b015040156b1e05081cdfe3733a"
 
 [[package]]
 name = "quote"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ version = "0.4.0"
 
 [features]
 default = []
+full = ["fluent", "locale"]
 fluent = ["fluent-templates"]
 locale = ["tera/date-locale"]
 env_logger = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ version = "0.4.0"
 [features]
 default = []
 fluent = ["fluent-templates"]
+locale = ["tera/date-locale"]
 env_logger = []
 
 [dependencies]


### PR DESCRIPTION
I spent a lot of time frustrated getting some templates right in a project a while back and ended up using something other than Tera (Handlebars) for it to get it out the door. I had to rework some other parts of it today and started fighting it again. The issue was a simple al outputting localized month names for dates in a table. First I tried generating localized versions of the context data with `jq` and various pre-processing and that was just a nightmare with a mess of files and non-deterministic array key sorting (it is easier to sort `+%Y%m%d` than `+%B`!). Then I tried post-processing the template after tera in the typesetting phase to match and replace things and that was spaghetti. Then I tried using the typesetter to localize based on the original date data, but it turns out convincing all the target environments to have the right system localization available is non-trivial.

In the end I finally ran across the Tera docs that note it can localize dates itself. Whew! This made the whole thing a breeze. Now I just have to use a binary built from my fork :(

This adds about 1.3MB (6.4→7.4 with *fluent* also enabled) to the runtime binary, but for my use case it is *so* worth it. I suspect others might find this useful too. I really don't understand having a minimal/hampered version of Tera available when the language *can* do such nice things.

Like the *fluent* feature I gated this behind a non-default feature flag assuming you'd prefer that, but if it were my project I would just make it a default-on feature. Let me know if you want that changed.