### PR TITLE
Fix StripPrefixError on windows when including templates

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -55,11 +55,11 @@ fn main() -> Result<()> {
 	trace!("context:\n{:#?}", context);
 
 	let mut tera = if include {
-		let dir = if path.is_file() { path.parent().context("failed to get parent directory")? } else { &path };
+		let dir = if path.is_file() { path.parent().context("failed to get parent directory")?.to_path_buf() } else { path };
 
-		let glob = format!("{}/**/*", dir.to_str().context("invalid UTF8 string")?);
+		let glob = dir.join("**").join("*");
 
-		Tera::new(&glob)?
+		Tera::new(glob.to_str().context("invalid UTF8 string")?)?
 	} else {
 		Tera::default()
 	};

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,8 @@ fn main() -> Result<()> {
 	trace!("context:\n{:#?}", context);
 
 	let mut tera = if include {
-		let dir = if path.is_file() { path.parent().context("failed to get parent directory")?.to_path_buf() } else { path };
+		let dir =
+			if path.is_file() { path.parent().context("failed to get parent directory")?.to_path_buf() } else { path };
 
 		let glob = dir.join("**").join("*");
 


### PR DESCRIPTION
Hello!
My colleagues use windows and were surprised by an error when trying to include other templates.
I was able to track this down to the glob pattern creation logic, which has unix path separators hardcoded.
Simply using `Path.join` instead of the custom formatting seems to have resolved the issue for both of them.

Thanks for this cli, its a simple solution for our simple problem!